### PR TITLE
Implemented new Biolo skills  (#7987)

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41549,6 +41549,96 @@ Body:
       Weapon:
         1hAxe: true
         2hAxe: true
+  - Id: 6005
+    Name: BO_EXPLOSIVE_POWDER
+    Description: Explosive Powder
+    MaxLevel: 5
+    Type: Weapon
+    TargetType: Self
+    DamageFlags:
+      Splash: true
+    Hit: Multi_Hit
+    HitCount: 3
+    Element: Weapon
+    GiveAp: 2
+    SplashArea: 3
+    CastCancel: true
+    AfterCastActDelay: 250
+    Cooldown: 700
+    Requires:
+      SpCost:
+        - Level: 1
+          Amount: 69
+        - Level: 2
+          Amount: 76
+        - Level: 3
+          Amount: 83
+        - Level: 4
+          Amount: 90
+        - Level: 5
+          Amount: 97
+  - Id: 6006
+    Name: BO_MAYHEMIC_THORNS
+    Description: Mayhemic Thorns
+    MaxLevel: 10
+    Type: Weapon
+    TargetType: Attack
+    DamageFlags:
+      Splash: true
+      Critical: true
+    Hit: Multi_Hit
+    HitCount: 3
+    Element: Weapon
+    Range: 9
+    GiveAp: 2
+    SplashArea:
+      - Level: 1
+        Area: 3
+      - Level: 2
+        Area: 3
+      - Level: 3
+        Area: 3
+      - Level: 4
+        Area: 3
+      - Level: 5
+        Area: 3
+      - Level: 6
+        Area: 4
+      - Level: 7
+        Area: 4
+      - Level: 8
+        Area: 4
+      - Level: 9
+        Area: 4
+      - Level: 10
+        Area: 4
+    CastCancel: true
+    CastTime: 1000
+    FixedCastTime: 500
+    AfterCastActDelay: 150
+    Cooldown: 700
+    Requires:
+      SpCost:
+        - Level: 1
+          Amount: 68
+        - Level: 2
+          Amount: 70
+        - Level: 3
+          Amount: 72
+        - Level: 4
+          Amount: 74
+        - Level: 5
+          Amount: 76
+        - Level: 6
+          Amount: 78
+        - Level: 7
+          Amount: 80
+        - Level: 8
+          Amount: 82
+        - Level: 9
+          Amount: 84
+        - Level: 10
+          Amount: 86
   - Id: 8001
     Name: HLIF_HEAL
     Description: Healing Touch

--- a/db/re/skill_tree.yml
+++ b/db/re/skill_tree.yml
@@ -7329,6 +7329,18 @@ Body:
             Level: 3
           - Name: BO_WOODEN_FAIRY
             Level: 3
+      - Name: BO_EXPLOSIVE_POWDER
+        MaxLevel: 5
+        Requires:
+          - Name: BO_BIONICS_M
+            Level: 3
+      - Name: BO_MAYHEMIC_THORNS
+        MaxLevel: 10
+        Requires:
+          - Name: BO_BIONICS_M
+            Level: 5
+          - Name: BO_EXPLOSIVE_POWDER
+            Level: 3
   - Job: Abyss_Chaser
     Inherit:
       Novice: true

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5644,6 +5644,20 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 
 			RE_LVL_DMOD(100);
 			break;
+		case BO_EXPLOSIVE_POWDER:
+			skillratio += -100 + 400 + 550 * skill_lv;
+			skillratio += 5 * sstatus->pow;
+			if (sc && sc->getSCE(SC_RESEARCHREPORT))
+				skillratio += 100 * skill_lv;
+			RE_LVL_DMOD(100);
+			break;
+		case BO_MAYHEMIC_THORNS:
+			skillratio += -100 + 200 + 300 * skill_lv;
+			skillratio += 5 * sstatus->pow;
+			if (sc && sc->getSCE(SC_RESEARCHREPORT))
+				skillratio += 150;
+			RE_LVL_DMOD(100);
+			break;
 		case TR_ROSEBLOSSOM:
 			skillratio += -100 + 200 + 2000 * skill_lv;
 
@@ -6662,6 +6676,14 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 			case MT_MIGHTY_SMASH:
 				if (sc && sc->getSCE(SC_AXE_STOMP))
 					wd.div_ = 7;
+				break;
+			case BO_EXPLOSIVE_POWDER:
+				if (sc && sc->getSCE(SC_RESEARCHREPORT))
+					wd.div_ = 5;
+				break;
+			case BO_MAYHEMIC_THORNS:
+				if (sc && sc->getSCE(SC_RESEARCHREPORT))
+					wd.div_ = 4;
 				break;
 		}
 	} else {

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5666,6 +5666,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case EM_EL_STORM_WIND:
 	case EM_EL_AVALANCHE:
 	case EM_EL_DEADLY_POISON:
+	case BO_EXPLOSIVE_POWDER:
+	case BO_MAYHEMIC_THORNS:
 		if( flag&1 ) {//Recursive invocation
 			int sflag = skill_area_temp[0] & 0xFFF;
 			int heal = 0;
@@ -5732,6 +5734,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				case LG_EARTHDRIVE:
 				case GN_CARTCANNON:
 				case SU_SCRATCH:
+				case BO_MAYHEMIC_THORNS:
 				case DK_HACKANDSLASHER:
 				case MT_SPARK_BLASTER:
 					clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
@@ -8492,6 +8495,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case MT_AXE_STOMP:
 	case MT_MIGHTY_SMASH:
 	case ABC_ABYSS_DAGGER:
+	case BO_EXPLOSIVE_POWDER:
 	{
 		status_change *sc = status_get_sc(src);
 		int starget = BL_CHAR|BL_SKILL;


### PR DESCRIPTION
* Implemented BO_EXPLOSIVE_POWDER
- Deals melee physical damage to all targets around the user.
- Doesn't need any catalyst.
- When using while under Research Report buff, increases damage and number of hit.
- Recovers 2 AP.
- Fixed casting time : - (based on level 5).
- Variable Casting time : - (based on level 5).
- Cooldown: 0.7 seconds (based on level 5).
- Global cool time : 0.25 seconds (based on level 5).

* Implemented BO_MAYHEMIC_THORNS
- Deals long ranged physical damage to the target and surrounding enemies around the target with the range up to 9x9 cells.
- Doesn't need any catalyst.
- Has a chance to trigger critical, the critical chance is the user's cri.
- When using while under Research Report buff, increases damage and number of hit.
- Recovers 2 AP.
- Fixed casting time : 0.5 seconds (based on level 10).
- Variable Casting time : 1 second (based on level 10).
- Cooldown: 0.7 seconds (based on level 10).
- Global cool time : 0.15 seconds (based on level 10).

* Skills updated to 2nd rebalance

Credit to @datawulf

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
